### PR TITLE
Removed lodash dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
   "author": "Lars Tadema <lars.tadema@anchor.chat>",
   "license": "MIT",
   "dependencies": {
-    "debug": "^3.1.0",
-    "lodash.foreach": "^4.5.0",
-    "lodash.sortby": "^4.7.0"
+    "debug": "^3.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/queue.js
+++ b/src/queue.js
@@ -1,5 +1,3 @@
-import forEach from 'lodash.foreach';
-import sortBy from 'lodash.sortby';
 import { getClient } from './socket';
 
 /**
@@ -46,9 +44,19 @@ const runQueue = (callback = () => {}) => {
   if (client && client.connected) {
     const items = [...Queue];
 
-    const sortedItems = sortBy(items, 'priority');
+    const sortedItems = items.sort((a, b) => {
+      if (a.priority < b.priority) {
+        return -1;
+      }
 
-    forEach(sortedItems, callback);
+      if (a.priority > b.priority) {
+        return 1;
+      }
+
+      return 0;
+    });
+
+    sortedItems.forEach(callback);
 
     return flush();
   }

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -148,16 +148,24 @@ describe('queue', () => {
         priority: 1
       };
 
+      const item3 = {
+        key: 'message2',
+        payload: {},
+        priority: 3
+      };
+
       queue.Queue.add(item1);
       queue.Queue.add(item2);
+      queue.Queue.add(item3);
 
       const callback = sandbox.spy();
 
       queue.runQueue(callback);
 
-      expect(callback).to.have.callCount(2);
+      expect(callback).to.have.callCount(3);
       expect(callback.firstCall.args[0]).to.equal(item2);
       expect(callback.secondCall.args[0]).to.equal(item1);
+      expect(callback.thirdCall.args[0]).to.equal(item3);
       expect(queue.Queue.size).to.equal(0);
     });
   });

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -149,7 +149,7 @@ describe('queue', () => {
       };
 
       const item3 = {
-        key: 'message2',
+        key: 'message3',
         payload: {},
         priority: 3
       };


### PR DESCRIPTION
Removed lodash dependencies as the functions used can just be implemented in pure JS. This will drop the package size by 46%.

<img width="1306" alt="screen shot 2018-04-19 at 14 41 36" src="https://user-images.githubusercontent.com/16486197/38992181-3ab81710-43e0-11e8-9d11-ae181096c6db.png">
